### PR TITLE
Disable multiplayer damage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ group = project.maven_group
 minecraft {
 }
 
+repositories{
+	maven { url 'http://server.bbkr.space:8081/artifactory/libs-release' }
+}
+
 dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -22,6 +26,11 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
+	modCompile "io.github.cottonmc.cotton:cotton-config:1.0.0-rc.7"
+
+	include "io.github.cottonmc:Jankson-Fabric:3.0.0+j1.2.0"
+	include "io.github.cottonmc.cotton:cotton-logging:1.0.0-rc.4"
+	include "io.github.cottonmc.cotton:cotton-config:1.0.0-rc.7"
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
 }

--- a/src/main/java/net/szum123321/the_loved_ones/ConfigHandler.java
+++ b/src/main/java/net/szum123321/the_loved_ones/ConfigHandler.java
@@ -1,0 +1,18 @@
+package net.szum123321.the_loved_ones;
+
+import blue.endless.jankson.Comment;
+import io.github.cottonmc.cotton.config.annotations.ConfigFile;
+
+@SuppressWarnings("CanBeFinal")
+@ConfigFile(name = "./TheLovedOnes/config")
+public class ConfigHandler {
+    @Comment("\nShould pets be damaged by other players when PVP is enabled?\n")
+    public boolean petsDamagePVP = true;
+
+    @Comment("\nShould pets be damaged by other players when PVP is disabled?\n")
+    public boolean petsDamageNoPVP = false;
+
+    @Comment("\nShould pets be damaged by other players when playing on LAN?\n")
+    public boolean petsDamageOnLAN = false;
+
+}

--- a/src/main/java/net/szum123321/the_loved_ones/TheLovedOnes.java
+++ b/src/main/java/net/szum123321/the_loved_ones/TheLovedOnes.java
@@ -12,7 +12,5 @@ public class TheLovedOnes implements ModInitializer {
     @Override
     public void onInitialize() {
         config = ConfigManager.loadConfig(ConfigHandler.class);
-        logger.debug("Loaded config?");
-        System.out.println("Config Loaded");
     }
 }

--- a/src/main/java/net/szum123321/the_loved_ones/TheLovedOnes.java
+++ b/src/main/java/net/szum123321/the_loved_ones/TheLovedOnes.java
@@ -1,0 +1,18 @@
+package net.szum123321.the_loved_ones;
+
+import io.github.cottonmc.cotton.config.ConfigManager;
+import io.github.cottonmc.cotton.logging.ModLogger;
+import net.fabricmc.api.ModInitializer;
+
+
+public class TheLovedOnes implements ModInitializer {
+    public static ModLogger logger = new ModLogger("the_loved_ones", "The Loved Ones");
+    public static ConfigHandler config;
+
+    @Override
+    public void onInitialize() {
+        config = ConfigManager.loadConfig(ConfigHandler.class);
+        logger.debug("Loaded config?");
+        System.out.println("Config Loaded");
+    }
+}

--- a/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
+++ b/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
@@ -29,6 +29,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.szum123321.the_loved_ones.TheLovedOnes;
 
 @Mixin(AnimalEntity.class)
 public abstract class AnimalEntityMixin extends PassiveEntity {
@@ -41,10 +42,23 @@ public abstract class AnimalEntityMixin extends PassiveEntity {
         if(!this.world.isClient() && (Object)this instanceof TameableEntity) {
             TameableEntity it = (TameableEntity)(Object)this;
 
-            if(it.getOwner() != null) {
+            if(it.isTamed()) {
                 if(source.getAttacker() instanceof PlayerEntity) {
-                    if(source.getAttacker() == it.getOwner())
-                        ci.setReturnValue(false);
+
+                    if(getServer().isSinglePlayer()) {
+                        //Check if attacking source is owner or pets damage on LAN is disabled
+                        if (source.getAttacker().getUuid() == it.getOwnerUuid() || !TheLovedOnes.config.petsDamageOnLAN)
+                            ci.setReturnValue(false);
+                    } else {
+                        // Check if PVP is enabled
+                        if(getServer().isPvpEnabled())
+                            if(!TheLovedOnes.config.petsDamagePVP)
+                                ci.setReturnValue(false);
+                        else
+                            if(!TheLovedOnes.config.petsDamageNoPVP)
+                                ci.setReturnValue(false);
+
+                    }
                 }
             }
         }

--- a/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
+++ b/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
@@ -47,7 +47,7 @@ public abstract class AnimalEntityMixin extends PassiveEntity {
 
                     if(getServer().isSinglePlayer()) {
                         //Check if attacking source is owner or pets damage on LAN is disabled
-                        if (source.getAttacker().getUuid() == it.getOwnerUuid() || !TheLovedOnes.config.petsDamageOnLAN)
+                        if (source.getAttacker().getUuid() == it.getOwnerUuid() || TheLovedOnes.config.petsDamageOnLAN == false)
                             ci.setReturnValue(false);
                     } else {
 
@@ -56,13 +56,13 @@ public abstract class AnimalEntityMixin extends PassiveEntity {
                             ci.setReturnValue(false);
 
                         // Check if PVP is enabled
-                        if(getServer().isPvpEnabled())
-                            if(!TheLovedOnes.config.petsDamagePVP)
+                        if(getServer().isPvpEnabled()) {
+                            if (TheLovedOnes.config.petsDamagePVP == false)
                                 ci.setReturnValue(false);
-                        else
-                            if(!TheLovedOnes.config.petsDamageNoPVP)
+                        } else {
+                            if (TheLovedOnes.config.petsDamageNoPVP == false)
                                 ci.setReturnValue(false);
-
+                        }
                     }
                 }
             }

--- a/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
+++ b/src/main/java/net/szum123321/the_loved_ones/mixin/AnimalEntityMixin.java
@@ -50,6 +50,11 @@ public abstract class AnimalEntityMixin extends PassiveEntity {
                         if (source.getAttacker().getUuid() == it.getOwnerUuid() || !TheLovedOnes.config.petsDamageOnLAN)
                             ci.setReturnValue(false);
                     } else {
+
+                        //Check if attacking source is owner
+                        if (source.getAttacker().getUuid() == it.getOwnerUuid())
+                            ci.setReturnValue(false);
+
                         // Check if PVP is enabled
                         if(getServer().isPvpEnabled())
                             if(!TheLovedOnes.config.petsDamagePVP)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,11 @@
   "icon": "assets/the_loved_ones/pets.png",
 
   "environment": "*",
+  "entrypoints": {
+    "main": [
+      "net.szum123321.the_loved_ones.TheLovedOnes"
+    ]
+  },
 
   "mixins": [
     "tlo.mixins.json"


### PR DESCRIPTION
Implements #1 

Implements a simple config file with three options
* Disable pets being damaged by other players when PVP is enabled (`petsDamagePVP`)
* Disable pets being damaged by other players when PVP is disabled (`petsDamageNoPVP`)
* Disable pets being damaged by other players over LAN (`petsDamageOnLAN`)

**Further considerations:**
* Implementing checks for teams & teams disabling friendly fire (the vanilla way to disable PVP on a LAN world). Not implemented as teams seem to be based purely off username, not UUID.
* Adding commands for operators to change the config options